### PR TITLE
Prompt Guard UI Bug in LLM Response

### DIFF
--- a/src/app/features/ChatWindow/index.tsx
+++ b/src/app/features/ChatWindow/index.tsx
@@ -140,7 +140,7 @@ const ChatWindow = () => {
         const pgMsg: ChatMessage = {
           hash: hashCode(JSON.stringify(promptResp)),
           type: "prompt_guard",
-          output: JSON.stringify(promptResp),
+          output: JSON.stringify(promptResp?.result),
         };
         setMessages((prevMessages) => [...prevMessages, pgMsg]);
 


### PR DESCRIPTION
After user submits a message, the `promptResp` passed into the new chatMessage created was sending the complete API response instead of just the `result` Object.

This caused Prompt Guard to show a `Benign` response on the UI while showing a `Detected` response on the right hand panel.