### PR TITLE
Remove `malicious_entity_count`

### DIFF
--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -44,8 +44,6 @@ export async function POST(request: NextRequest) {
         recipe: body.recipe,
       }),
       findings: JSON.stringify(response.result.detectors),
-      malicious_entity_count:
-        response.result.detectors.malicious_entity?.data?.entities?.length || 0,
       actor: username,
     },
   };

--- a/src/app/features/ChatWindow/index.tsx
+++ b/src/app/features/ChatWindow/index.tsx
@@ -342,7 +342,6 @@ const ChatWindow = () => {
             input: event.envelope.event.input,
             output: event.envelope.event.output,
             findings: event.envelope.event.findings,
-            malicious_count: event.envelope.event.malicious_entity_count,
           };
           return message;
         });


### PR DESCRIPTION
Not present in the latest version of the audit log schema.