### PR TITLE
Replace pangea_llm_prompt_guard recipe

### DIFF
--- a/src/app/features/ChatWindow/utils.ts
+++ b/src/app/features/ChatWindow/utils.ts
@@ -37,7 +37,7 @@ export const callInputDataGuard = async (
   overrides?: DetectorOverrides,
 ) => {
   const payload = {
-    recipe: "pangea_llm_prompt_guard",
+    recipe: "pangea_prompt_guard",
     messages,
     overrides,
   };


### PR DESCRIPTION
The recipe appears to have been removed at some point. There isn't really an equivalent now, so settled on pangea_prompt_guard.